### PR TITLE
Update requirements to add 3.8 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-lightgbm==2.1.2
-numpy==1.17.1
-scikit-learn==0.21.3
-joblib==0.13.2
-pytest==3.10.1
-fasttext==0.9.1
+lightgbm~=2.1.2
+numpy~=1.19.1
+scikit-learn>=0.21.3,<0.24
+joblib>=0.13.2,<0.17
+pytest
+fasttext


### PR DESCRIPTION
Based on the suggestions from Eshaan7 and ralphje in #13 , I've updated the requirements to allow for installation in Ubuntu 18 and 20 (python3.6 and 3.8). 