### PR TITLE
packaging: distutils -> setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2019 FireEye, Inc. All Rights Reserved.
 
-from distutils.core import setup
+from setuptools import setup
 import os
 
 _version = '0.20191202'


### PR DESCRIPTION
`install_requires` or `entry_points`, `setuptools` are features only available on setuptools that are not supported by distutils. (see [this SO answer](https://stackoverflow.com/questions/8295644/pypi-userwarning-unknown-distribution-option-install-requires#answer-58228515)).

## Actual behavior

`python setup.py install` will generate those 3 warnings:

```
Writing /build/stringsifter/pkg/stringsifter/usr/lib/python3.8/site-packages/stringsifter-0.20191202-py3.8.egg-info
/usr/lib/python3.8/distutils/dist.py:274: UserWarning: Unknown distribution option: 'entry_points'
  warnings.warn(msg)
/usr/lib/python3.8/distutils/dist.py:274: UserWarning: Unknown distribution option: 'install_requires'
  warnings.warn(msg)
/usr/lib/python3.8/distutils/dist.py:274: UserWarning: Unknown distribution option: 'python_requires'
  warnings.warn(msg)
```

And as a result, as entry_points was ignore, `rank_strings` and `flarestrings` are not available in the PATH, users have to call `python -m stringsifter.rank_strings` or `python -m stringsifter.flarestrings` which is not suitable.

## Expected behavior

By replacing the packaging from distutils to setuptools (what the PR does which you can test with the sed command bellow), `rank_strings` and `flarestrings` are both available from the path because entry_points was taken into accounts when installing with `python setup.py install`.

```
sed -i 's/from distutils.core import setup/from setuptools import setup/' setup.py
```

Except fixing this the actual behavior is kept unchanged. This won't change `pip install -e .` install either as pip can either use both packaging methods.
